### PR TITLE
perf: Improve performance of build_style method

### DIFF
--- a/lib/phlex/variants.rb
+++ b/lib/phlex/variants.rb
@@ -27,14 +27,19 @@ module Phlex
 
       # @api private
       def build_variants_style(variants)
-        self::STYLE_DEFAULTS.merge(variants.compact).map do |variant, option|
-          value = self::STYLE_VARIANTS.dig(variant, option)
+        variants = variants.compact
+        variants = self::STYLE_DEFAULTS.merge(variants) unless self::STYLE_DEFAULTS.empty?
 
-          if value.nil?
-            raise VariantNotFoundError, "Variant `#{variant}: #{option.inspect}` doesn't exist"
+        variants.map do |variant, option|
+          options = self::STYLE_VARIANTS[variant]
+
+          if options
+            value = options[option]
+
+            next value if value
           end
 
-          value
+          raise VariantNotFoundError, "Variant `#{variant}: #{option.inspect}` doesn't exist"
         end
       end
     end


### PR DESCRIPTION
```
ruby 3.4.0dev (2024-02-27T20:49:04Z master edc7b73fc4) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                 New    77.023k i/100ms
                 Old    54.003k i/100ms
Calculating -------------------------------------
                 New    827.226k (± 0.6%) i/s -      4.159M in   5.028123s
                 Old    551.346k (± 0.6%) i/s -      2.808M in   5.093489s

Comparison:
                 New:   827226.3 i/s
                 Old:   551346.0 i/s - 1.50x  slower
```